### PR TITLE
docs(common): Fix broken readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ const requestSender = createRequestSender();
 
 // GET request
 requestSender.get('/foobars')
-    .then(({ body }) => console.log(response.body));
+    .then(({ body }) => console.log(body));
 
 // POST request
 requestSender.post('/foobars', { body: { name: 'Foobar' } })
-    .then(({ body }) => console.log(response.body));
+    .then(({ body }) => console.log(body));
 ```
 
 To cancel a pending request


### PR DESCRIPTION
What
----
Change the examples in the readme to log the `body`, not the
`response.body`.

Why
---
The current example will throw a reference error, and may be tricky for
people not familiar with ES6 syntax to fix.

@bigcommerce/frontend
