### PR TITLE
CHECKOUT-3006: Allow support for newer version of Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,4 @@ dist: trusty
 
 sudo: false
 
-before_install:
-    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
-    - export PATH=$HOME/.yarn/bin:$PATH
-
 script: yarn travis

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "lib/"
   ],
   "engines": {
-    "node": "^6.10.0",
-    "yarn": "^0.27.5"
+    "node": "^6.10.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What?
- Remove the Yarn version from engines and build with the latest version of Yarn

## Why?
- We were stuck in 0.27 because of ng-build. That's getting fixed. We shouldn't enforce that restriction in the dependencies.

## Testing / Proof
- Travis

@bigcommerce/frontend
