### PR TITLE
CHECKOUT-3008: Add TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Use a definition file for now until we have time to convert the source code
+ * into TypeScript
+ */
+
+export function createRequestSender(): RequestSender;
+
+export function createTimeout(delay?: number): Timeout;
+
+export interface RequestSender {
+    sendRequest<T = any>(url: string, options: RequestOptions): Promise<Response<T>>;
+    get<T = any>(url: string, options: RequestOptions): Promise<Response<T>>;
+    post<T = any>(url: string, options: RequestOptions): Promise<Response<T>>;
+    put<T = any>(url: string, options: RequestOptions): Promise<Response<T>>;
+    patch<T = any>(url: string, options: RequestOptions): Promise<Response<T>>;
+    delete<T = any>(url: string, options: RequestOptions): Promise<Response<T>>;
+}
+
+export interface Response<T = any> {
+    body: T;
+    headers: { [key: string]: any; };
+    status: number;
+    statusText: string;
+}
+
+export interface RequestOptions {
+    body?: any;
+    credentials?: boolean;
+    headers?: { [key: string]: any };
+    method?: string;
+    params?: { [key: string]: any };
+    timeout?: Timeout;
+}
+
+export interface Timeout {
+    start(): void;
+    complete(): void;
+    onComplete(callback: () => void): void;
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.1",
   "description": "HTTP request client for browsers",
   "main": "lib/index.js",
+  "typings": "index.d.ts",
   "files": [
-    "lib/"
+    "lib/",
+    "index.d.ts"
   ],
   "engines": {
     "node": "^6.10.0"


### PR DESCRIPTION
## What?
* Add `index.d.ts` file.

## Why?
* We'll convert the source code into TypeScript (CHECKOUT-2899). But for now, we can just use a `d.ts` file.

## Testing / Proof
* Manual

@bigcommerce/frontend
