### PR TITLE
CHECKOUT-3457: Configure `RequestSender` with host URL

### DIFF
--- a/src/create-request-sender.ts
+++ b/src/create-request-sender.ts
@@ -3,11 +3,13 @@ import * as cookie from 'js-cookie';
 import PayloadTransformer from './payload-transformer';
 import RequestFactory from './request-factory';
 import RequestSender from './request-sender';
+import RequestSenderOptions from './request-sender-options';
 
-export default function createRequestSender(): RequestSender {
+export default function createRequestSender(options?: RequestSenderOptions): RequestSender {
     return new RequestSender(
         new RequestFactory(),
         new PayloadTransformer(),
-        cookie
+        cookie,
+        options
     );
 }

--- a/src/request-sender-options.ts
+++ b/src/request-sender-options.ts
@@ -1,0 +1,3 @@
+export default interface RequestSenderOptions {
+    host?: string;
+}

--- a/src/request-sender.spec.ts
+++ b/src/request-sender.spec.ts
@@ -178,6 +178,42 @@ describe('RequestSender', () => {
             expect(request.abort).toHaveBeenCalled();
             expect(payloadTransformer.toResponse).toHaveBeenCalledWith(request);
         });
+
+        it('prepends host to request URL', () => {
+            const options = { host: 'https://foobar.com/' };
+            const relativeUrl = '/api/endpoint';
+
+            requestSender = new RequestSender(requestFactory, payloadTransformer, cookie, options);
+
+            requestSender.sendRequest(relativeUrl);
+
+            expect(requestFactory.createRequest).toHaveBeenCalledWith('https://foobar.com/api/endpoint', {
+                credentials: true,
+                headers: {
+                    Accept: 'application/json, text/plain, */*',
+                    'Content-Type': 'application/json',
+                },
+                method: 'GET',
+            });
+        });
+
+        it('does not prepend host to request URL if it is not relative URL', () => {
+            const options = { host: 'https://foobar.com/' };
+            const absoluteUrl = 'https://helloworld.com/api/endpoint';
+
+            requestSender = new RequestSender(requestFactory, payloadTransformer, cookie, options);
+
+            requestSender.sendRequest(absoluteUrl);
+
+            expect(requestFactory.createRequest).toHaveBeenCalledWith('https://helloworld.com/api/endpoint', {
+                credentials: true,
+                headers: {
+                    Accept: 'application/json, text/plain, */*',
+                    'Content-Type': 'application/json',
+                },
+                method: 'GET',
+            });
+        });
     });
 
     describe('#get()', () => {

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -5,6 +5,7 @@ import isPromise from './is-promise';
 import PayloadTransformer from './payload-transformer';
 import RequestFactory from './request-factory';
 import RequestOptions from './request-options';
+import RequestSenderOptions from './request-sender-options';
 import Response from './response';
 import Timeout from './timeout';
 
@@ -12,12 +13,13 @@ export default class RequestSender {
     constructor(
         private _requestFactory: RequestFactory,
         private _payloadTransformer: PayloadTransformer,
-        private _cookie: CookiesStatic
+        private _cookie: CookiesStatic,
+        private _options?: RequestSenderOptions
     ) {}
 
     sendRequest<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
         const requestOptions = this._mergeDefaultOptions(options);
-        const request = this._requestFactory.createRequest(url, requestOptions);
+        const request = this._requestFactory.createRequest(this._prependHost(url), requestOptions);
 
         return new Promise((resolve, reject) => {
             const requestHandler = () => {
@@ -85,5 +87,13 @@ export default class RequestSender {
         }
 
         return merge({}, defaultOptions, options);
+    }
+
+    private _prependHost(url: string): string {
+        if (!this._options || !this._options.host || /^https?:\/\//.test(url)) {
+            return url;
+        }
+
+        return `${this._options.host.replace(/\/$/, '')}/${url.replace(/^\//, '')}`;
     }
 }


### PR DESCRIPTION
## What?
* Configure `RequestSender` with default host URL.

## Why?
* So you can set a host URL for all requests.
* Only apply the default host if the request URL is not a relative one.

## Testing / Proof
* Unit

@bigcommerce/frontend
