### PR TITLE
CHECKOUT-3703: Only include `Content-Type` header if there is a request body

### DIFF
--- a/src/request-sender.spec.ts
+++ b/src/request-sender.spec.ts
@@ -58,6 +58,18 @@ describe('RequestSender', () => {
             });
         });
 
+        it('creates a HTTP request without content-type if payload is not provided', () => {
+            requestSender.sendRequest(url, { method: 'POST' });
+
+            expect(requestFactory.createRequest).toHaveBeenCalledWith(url, {
+                credentials: true,
+                headers: {
+                    Accept: 'application/json, text/plain, */*',
+                },
+                method: 'POST',
+            });
+        });
+
         it('creates a HTTP request with custom options', () => {
             const options = {
                 body: 'foobar',

--- a/src/request-sender.spec.ts
+++ b/src/request-sender.spec.ts
@@ -34,9 +34,27 @@ describe('RequestSender', () => {
                 credentials: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
-                    'Content-Type': 'application/json',
                 },
                 method: 'GET',
+            });
+        });
+
+        it('creates a HTTP request with content-type if payload is provided', () => {
+            const options = {
+                body: { message: 'hello world' },
+                method: 'POST',
+            };
+
+            requestSender.sendRequest(url, options);
+
+            expect(requestFactory.createRequest).toHaveBeenCalledWith(url, {
+                body: options.body,
+                credentials: true,
+                headers: {
+                    Accept: 'application/json, text/plain, */*',
+                    'Content-Type': 'application/json',
+                },
+                method: 'POST',
             });
         });
 
@@ -72,7 +90,6 @@ describe('RequestSender', () => {
                 headers: {
                     Accept: 'text/plain',
                     Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
-                    'Content-Type': 'application/json',
                 },
                 method: 'POST',
             });
@@ -191,7 +208,6 @@ describe('RequestSender', () => {
                 credentials: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
-                    'Content-Type': 'application/json',
                 },
                 method: 'GET',
             });
@@ -209,7 +225,6 @@ describe('RequestSender', () => {
                 credentials: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
-                    'Content-Type': 'application/json',
                 },
                 method: 'GET',
             });

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -75,7 +75,6 @@ export default class RequestSender {
             credentials: true,
             headers: {
                 Accept: 'application/json, text/plain, */*',
-                'Content-Type': 'application/json',
             },
             method: 'GET',
         };
@@ -84,6 +83,10 @@ export default class RequestSender {
 
         if (csrfToken && defaultOptions.headers) {
             defaultOptions.headers['X-XSRF-TOKEN'] = csrfToken;
+        }
+
+        if (options && options.body && defaultOptions.headers) {
+            defaultOptions.headers['Content-Type'] = 'application/json';
         }
 
         return merge({}, defaultOptions, options);


### PR DESCRIPTION
## What?
* Only include `Content-Type` header if there is a request body.

## Why?
* You should only need to specify the content type of a request if there's a body. If not, we can simply omit it.
* Otherwise, for CORS requests, we could be doing unnecessary preflight checks. Browsers automatically make a preflight check if the request contains a header that is not considered as [CORS-safelisted](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).

## Testing / Proof
* Unit

@bigcommerce/frontend @bigcommerce/checkout 
