### PR TITLE
CHECKOUT-4149: Transform URL encoded content if specified in request header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "integrity": "sha512-vPT5MV1pD71RFUD0ytp6Yw51W6zKJ9Qn2AcJXSD2TZqYKaXUtCxB3WZIXXFZtbAEVMgC59nmvVPSOH0EIvkaZg=="
     },
     "@types/lodash": {
-      "version": "4.14.110",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.110.tgz",
-      "integrity": "sha512-iXYLa6olt4tnsCA+ZXeP6eEW3tk1SulWeYyP/yooWfAtXjozqXgtX4+XUtMuOCfYjKGz3F34++qUc3Q+TJuIIw=="
+      "version": "4.14.133",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.133.tgz",
+      "integrity": "sha512-/3JqnvPnY58GLzG3Y7fpphOhATV1DDZ/Ak3DQufjlRK5E4u+s0CfClfNFtAGBabw+jDGtRFbOZe+Z02ZMWCBNQ=="
     },
     "@types/node": {
       "version": "10.5.1",
@@ -84,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2092,7 +2093,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2116,13 +2118,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2139,19 +2143,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2282,7 +2289,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2296,6 +2304,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2312,6 +2321,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2320,13 +2330,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2347,6 +2359,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2435,7 +2448,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2449,6 +2463,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2544,7 +2559,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2586,6 +2602,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2607,6 +2624,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2655,13 +2673,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4062,10 +4082,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -4102,7 +4121,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   },
   "dependencies": {
     "@types/js-cookie": "^2.1.0",
-    "@types/lodash": "^4.14.109",
+    "@types/lodash": "^4.14.133",
     "@types/query-string": "^5.1.0",
     "js-cookie": "^2.1.4",
+    "lodash": "^4.17.11",
     "query-string": "^5.0.0",
     "tslib": "^1.8.0"
   },

--- a/src/payload-transformer.spec.ts
+++ b/src/payload-transformer.spec.ts
@@ -1,4 +1,5 @@
 import PayloadTransformer from './payload-transformer';
+import toFormUrlEncoded from './to-form-url-encoded';
 
 describe('PayloadTransformer', () => {
     let payloadTransformer: PayloadTransformer;
@@ -25,6 +26,30 @@ describe('PayloadTransformer', () => {
 
             expect(payloadTransformer.toRequestBody(options))
                 .toEqual(options.body);
+        });
+
+        it('transforms request body into URL encoded string if it is specified in request header', () => {
+            const options = {
+                body: { message: 'foobar' },
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+            };
+
+            expect(payloadTransformer.toRequestBody(options))
+                .toEqual(toFormUrlEncoded(options.body));
+        });
+
+        it('does not transform request body into URL encoded string if it is not specified in request header', () => {
+            const options = {
+                body: { message: 'foobar' },
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            };
+
+            expect(payloadTransformer.toRequestBody(options))
+                .not.toEqual(toFormUrlEncoded(options.body));
         });
     });
 

--- a/src/payload-transformer.ts
+++ b/src/payload-transformer.ts
@@ -1,15 +1,23 @@
 import Headers from './headers';
 import RequestOptions from './request-options';
 import Response from './response';
+import toFormUrlEncoded from './to-form-url-encoded';
 
 const JSON_CONTENT_TYPE_REGEXP = /application\/(\w+\+)?json/;
+const FORM_URLENCODED_CONTENT_TYPE_REGEXP = /application\/x-www-form-urlencoded/;
 
 export default class PayloadTransformer {
     toRequestBody(options: RequestOptions): any {
         const contentType = options.headers ? this._getHeader(options.headers, 'Content-Type') : '';
 
-        if (options.body && JSON_CONTENT_TYPE_REGEXP.test(contentType)) {
-            return JSON.stringify(options.body);
+        if (options.body) {
+            if (JSON_CONTENT_TYPE_REGEXP.test(contentType)) {
+                return JSON.stringify(options.body);
+            }
+
+            if (FORM_URLENCODED_CONTENT_TYPE_REGEXP.test(contentType)) {
+                return toFormUrlEncoded(options.body);
+            }
         }
 
         return options.body;

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -1,5 +1,5 @@
 import { CookiesStatic } from 'js-cookie';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 import isPromise from './is-promise';
 import PayloadTransformer from './payload-transformer';

--- a/src/to-form-url-encoded.spec.ts
+++ b/src/to-form-url-encoded.spec.ts
@@ -1,0 +1,32 @@
+import toFormUrlEncoded from './to-form-url-encoded';
+
+describe('toFormUrlEncoded()', () => {
+    it('encodes given object to url encoded string', () => {
+        const data = {
+            A: 'A',
+            B: 'B',
+        };
+
+        expect(toFormUrlEncoded(data))
+            .toEqual('A=A&B=B');
+    });
+
+    it('encodes nested object to url encoded string', () => {
+        const data = {
+            A: 'A',
+            B: {
+                value: 'B',
+            },
+        };
+
+        expect(toFormUrlEncoded(data))
+            .toEqual('A=A&B=%7B%22value%22%3A%22B%22%7D');
+    });
+
+    it('does not do anything if data is already encoded', () => {
+        const data = 'A=A&B=B';
+
+        expect(toFormUrlEncoded(data))
+            .toEqual(data);
+    });
+});

--- a/src/to-form-url-encoded.ts
+++ b/src/to-form-url-encoded.ts
@@ -1,0 +1,18 @@
+export default function toFormUrlEncoded(data: any): string {
+    if (typeof data !== 'object' || data === null) {
+        return data;
+    }
+
+    return Object.keys(data)
+        .filter(key => data[key] !== undefined)
+        .map(key => {
+            const value = data[key];
+
+            if (typeof value === 'string') {
+                return `${key}=${encodeURIComponent(value)}`;
+            }
+
+            return `${key}=${encodeURIComponent(JSON.stringify(value) || '')}`;
+        })
+        .join('&');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,


### PR DESCRIPTION
## What?
* Transform URL encoded content if specified in the request header.

## Why?
* So users of the library don't have to convert it themselves.

## Testing / Proof
* Unit

@bigcommerce/checkout 
