### PR TITLE
feat(request): CHP-6060 adds optional cache functionality

### DIFF
--- a/src/cache.spec.ts
+++ b/src/cache.spec.ts
@@ -1,0 +1,53 @@
+import { DefaultCache } from './cache';
+import { getResponse } from './responses.mock';
+
+describe('DefaultCache', () => {
+    let cache: DefaultCache;
+
+    beforeEach(() => {
+        cache = new DefaultCache();
+    });
+
+    it('returns null when a cache key does not exist', () => {
+        expect(cache.read('https://example.com', {})).toBe(null);
+    });
+
+    it('returns a stored response', () => {
+        const response = getResponse('Test Body');
+        const url = 'https://example.com';
+
+        cache.write(url, {}, response);
+
+        expect(cache.read(url, {})).toBe(response);
+    });
+
+    it('reads a specific stored response', () => {
+        const response = getResponse('Test Body');
+        const url = 'https://example.com';
+
+        cache.write('/test/1', {}, getResponse('Test Body 1'));
+        cache.write(url, {}, response);
+        cache.write('/test/2', {}, getResponse('Test Body 2'));
+
+        expect(cache.read(url, {})).toBe(response);
+    });
+
+    it('stores cache in different keys when giving the same url with different params', () => {
+        const url = 'https://example.com';
+
+        const firstTestResponse = getResponse('Test Body 1');
+        const firstRequestOptions = { params: { testParam: 'first' } };
+
+        const secondTestResponse = getResponse('Test Body 2');
+        const secondRequestOptions = { params: { testParam: 'second' } };
+
+        cache.write(url, firstRequestOptions, firstTestResponse);
+        cache.write(url, secondRequestOptions, secondTestResponse);
+
+        const firstCachedResponse = cache.read(url, firstRequestOptions);
+        const secondCachedResponse = cache.read(url, secondRequestOptions);
+
+        expect(firstCachedResponse).toBe(firstTestResponse);
+        expect(secondCachedResponse).toBe(secondTestResponse);
+    });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,37 @@
+import * as queryString from 'query-string';
+
+import RequestOptions from './request-options';
+import Response from './response';
+
+export default interface Cache {
+    read<T>(url: string, options: RequestOptions): Response<T> | null;
+    write<T>(url: string, options: RequestOptions, response: Response<T>): void;
+}
+
+interface CacheMap {
+    [key: string]: Response<any>;
+}
+
+export class DefaultCache implements Cache {
+    private readonly _cache: CacheMap = {};
+
+    read<T>(url: string, options: RequestOptions): Response<T> | null {
+        const cacheKey = this.getKey(url, options.params);
+
+        return this._cache[cacheKey] || null;
+    }
+
+    write<T>(url: string, options: RequestOptions, response: Response<T>) {
+        const cacheKey = this.getKey(url, options.params);
+
+        this._cache[cacheKey] = response;
+    }
+
+    private getKey(url: string, params: object = {}) {
+        if (Object.keys(params).length === 0) {
+            return url;
+        }
+
+        return `${url}?${queryString.stringify(params)}`;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { default as Cache } from './cache';
 export { default as createRequestSender } from './create-request-sender';
 export { default as createTimeout } from './create-timeout';
 export { default as RequestSender } from './request-sender';

--- a/src/request-options.ts
+++ b/src/request-options.ts
@@ -3,6 +3,7 @@ import Timeout from './timeout';
 
 export default interface RequestOptions {
     body?: any;
+    cache?: boolean;
     credentials?: boolean;
     headers?: Headers;
     method?: string;

--- a/src/request-sender-options.ts
+++ b/src/request-sender-options.ts
@@ -1,3 +1,6 @@
+import Cache from './cache';
+
 export default interface RequestSenderOptions {
+    cache?: Cache;
     host?: string;
 }

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -1,6 +1,7 @@
 import { CookiesStatic } from 'js-cookie';
 import merge from 'lodash/merge';
 
+import Cache, { DefaultCache } from './cache';
 import isPromise from './is-promise';
 import PayloadTransformer from './payload-transformer';
 import RequestFactory from './request-factory';
@@ -10,15 +11,25 @@ import Response from './response';
 import Timeout from './timeout';
 
 export default class RequestSender {
+    private _cache: Cache;
+
     constructor(
         private _requestFactory: RequestFactory,
         private _payloadTransformer: PayloadTransformer,
         private _cookie: CookiesStatic,
-        private _options?: RequestSenderOptions
-    ) {}
+        private _options: RequestSenderOptions = {}
+    ) {
+        this._cache = this._options.cache || new DefaultCache();
+    }
 
     sendRequest<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
         const requestOptions = this._mergeDefaultOptions(options);
+        const cachedRequest = this._getCachedRequest<T>(url, requestOptions);
+
+        if (cachedRequest) {
+            return Promise.resolve(cachedRequest);
+        }
+
         const request = this._requestFactory.createRequest(this._prependHost(url), requestOptions);
 
         return new Promise((resolve, reject) => {
@@ -26,6 +37,7 @@ export default class RequestSender {
                 const response = this._payloadTransformer.toResponse(request);
 
                 if (response.status >= 200 && response.status < 300) {
+                    this._cacheRequest(url, requestOptions, response);
                     resolve(response);
                 } else {
                     reject(response);
@@ -93,10 +105,30 @@ export default class RequestSender {
     }
 
     private _prependHost(url: string): string {
-        if (!this._options || !this._options.host || /^https?:\/\//.test(url)) {
+        if (!this._options.host || /^https?:\/\//.test(url)) {
             return url;
         }
 
         return `${this._options.host.replace(/\/$/, '')}/${url.replace(/^\//, '')}`;
+    }
+
+    private _shouldCacheRequest(options: RequestOptions): boolean {
+        const method = options.method || 'GET';
+
+        return method.toUpperCase() === 'GET' && Boolean(options.cache);
+    }
+
+    private _getCachedRequest<T>(url: string, options: RequestOptions): Response<T> | null {
+        if (this._shouldCacheRequest(options)) {
+            return this._cache.read<T>(url, options);
+        }
+
+        return null;
+    }
+
+    private _cacheRequest<T>(url: string, options: RequestOptions, response: Response<T>): void {
+        if (this._shouldCacheRequest(options)) {
+            this._cache.write(url, options, response);
+        }
     }
 }


### PR DESCRIPTION
## What?
Adds a `cache: boolean` option to the requests, when set, it will store the `Response` (if successful) in memory using the url + params as key. If a `GET` request is made with the same `url` and `params` it will return the locally stored `Response`.

### Usage:
```js
import { createRequestSender } from '@bigcommerce/request-sender';

const http = createRequestSender();

// Triggers a network request
await http.get('/foobars', { cache: true });

// Doesn't trigger a network request since a request with the same url is already in cache
await http.get('/foobars', { cache: true });
```

### Advanced usage:
We also export a `Cache` interface. You can pass a custom `Cache` implementation as long as it implements the interface as an `option` (for backwards compat) when calling `createRequestSender`.

This allows the usage of more complex cache implementations such as: storing the `Responses` in `localStorage`, implement cache invalidation methods/strategies, customize how `keys` get generated, etc.

A contrived example of a `localStorage` cache with invalidation support:

```ts
class LocalStorageCache implements Cache {
  read<T>(url: string, _options: RequestOptions) {
    const response = localStorage.getItem(url);

    return response ? JSON.parse(response) : null;
  }

  write<T>(url: string, _options: RequestOptions, response: Response<T>) {
    localStorage.setItem(url, JSON.stringify(response))
  }

  invalidateByUrl(url: string) {
    localStorage.removeItem(url);
  }
}

const cache = new LocalStorageCache();
const http = createRequestSender({ cache });
```

## Why?
We have some use cases where we want to cache some requests regardless of `Cache-Control` headers.

## Testing / Proof
Tests

@bigcommerce/frontend