### PR TITLE
feat(request): CHP-6278 add request option to prevent param encoding

### DIFF
--- a/src/request-factory.spec.ts
+++ b/src/request-factory.spec.ts
@@ -40,16 +40,31 @@ describe('RequestFactory', () => {
             expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
         });
 
-        it('configures XHR object with parameterized URL', () => {
+        it('configures XHR object with encoded parameterized URL', () => {
             const xhr = requestFactory.createRequest(url, {
                 method: 'GET',
                 params: {
                     bar: 'bar',
-                    foobar: 'foobar',
+                    foo: 'foo',
+                    foobar: 'foo,bar',
                 },
             });
 
-            expect(xhr.open).toHaveBeenCalledWith('GET', `${url}?bar=bar&foobar=foobar`, true);
+            expect(xhr.open).toHaveBeenCalledWith('GET', `${url}?bar=bar&foo=foo&foobar=foo%2Cbar`, true);
+        });
+
+        it('configures XHR object with unencoded paramterized URL', () => {
+            const xhr = requestFactory.createRequest(url, {
+                encodeParams: false,
+                method: 'GET',
+                params: {
+                    bar: 'bar',
+                    foo: 'foo',
+                    foobar: 'foo,bar',
+                },
+            });
+
+            expect(xhr.open).toHaveBeenCalledWith('GET', `${url}?bar=bar&foo=foo&foobar=foo,bar`, true);
         });
     });
 });

--- a/src/request-factory.ts
+++ b/src/request-factory.ts
@@ -13,7 +13,7 @@ export default class RequestFactory {
     }
 
     private _configureRequest(xhr: XMLHttpRequest, url: string, options: RequestOptions = {}): void {
-        xhr.open(options.method || 'GET', this._formatUrl(url, options.params), true);
+        xhr.open(options.method || 'GET', this._formatUrl(url, options.params, options.encodeParams), true);
 
         if (options.headers) {
             this._configureRequestHeaders(xhr, options.headers);
@@ -34,11 +34,11 @@ export default class RequestFactory {
         });
     }
 
-    private _formatUrl(url: string, params?: object): string {
+    private _formatUrl(url: string, params?: object, encodeParams: boolean = true): string {
         if (!params || Object.keys(params).length === 0) {
             return url;
         }
 
-        return `${url}?${queryString.stringify(params)}`;
+        return `${url}?${queryString.stringify(params, { encode: encodeParams })}`;
     }
 }

--- a/src/request-options.ts
+++ b/src/request-options.ts
@@ -5,6 +5,7 @@ export default interface RequestOptions {
     body?: any;
     cache?: boolean;
     credentials?: boolean;
+    encodeParams?: boolean;
     headers?: Headers;
     method?: string;
     params?: { [key: string]: any };

--- a/src/request-sender.spec.ts
+++ b/src/request-sender.spec.ts
@@ -32,6 +32,7 @@ describe('RequestSender', () => {
 
             expect(requestFactory.createRequest).toHaveBeenCalledWith(url, {
                 credentials: true,
+                encodeParams: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
                 },
@@ -50,6 +51,7 @@ describe('RequestSender', () => {
             expect(requestFactory.createRequest).toHaveBeenCalledWith(url, {
                 body: options.body,
                 credentials: true,
+                encodeParams: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
                     'Content-Type': 'application/json',
@@ -63,6 +65,7 @@ describe('RequestSender', () => {
 
             expect(requestFactory.createRequest).toHaveBeenCalledWith(url, {
                 credentials: true,
+                encodeParams: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
                 },
@@ -74,6 +77,7 @@ describe('RequestSender', () => {
             const options = {
                 body: 'foobar',
                 credentials: false,
+                encodeParams: false,
                 headers: {
                     Accept: 'text/plain',
                     'Content-Type': 'text/plain',
@@ -88,6 +92,7 @@ describe('RequestSender', () => {
 
         it('creates a HTTP request with default options unless they are overridden', () => {
             const options = {
+                encodeParams: true,
                 headers: {
                     Accept: 'text/plain',
                     Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
@@ -99,6 +104,7 @@ describe('RequestSender', () => {
 
             expect(requestFactory.createRequest).toHaveBeenCalledWith(url, {
                 credentials: true,
+                encodeParams: true,
                 headers: {
                     Accept: 'text/plain',
                     Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
@@ -218,6 +224,7 @@ describe('RequestSender', () => {
 
             expect(requestFactory.createRequest).toHaveBeenCalledWith('https://foobar.com/api/endpoint', {
                 credentials: true,
+                encodeParams: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
                 },
@@ -235,6 +242,7 @@ describe('RequestSender', () => {
 
             expect(requestFactory.createRequest).toHaveBeenCalledWith('https://helloworld.com/api/endpoint', {
                 credentials: true,
+                encodeParams: true,
                 headers: {
                     Accept: 'application/json, text/plain, */*',
                 },

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -85,6 +85,7 @@ export default class RequestSender {
     private _mergeDefaultOptions(options?: RequestOptions): RequestOptions {
         const defaultOptions: Partial<RequestOptions> = {
             credentials: true,
+            encodeParams: true,
             headers: {
                 Accept: 'application/json, text/plain, */*',
             },


### PR DESCRIPTION
## What?
Add `encodeParam` request option. 

## Why?
`queryString.stringify` encodes the `params` by default and I want an option to prevent that default behavior.

## Testing / Proof
Locally.
Unit tests.

@bigcommerce/frontend
