### PR TITLE
docs(common): CHP-6278 add encodeParam documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ To manually complete a timeout.
 Request payload.
 Default: `null`
 
+#### encodeParams: boolean?
+URL encodes params.
+Default: `true`
+
 #### headers: Object?
 Request headers.
 Default: `{


### PR DESCRIPTION
## What?
Add `encodeParam` option to README. I knew I was forgetting something...