### PR TITLE
feat(common): CHP-6348 export Cache creator for reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 *.log
 /coverage
 /lib

--- a/src/cache.spec.ts
+++ b/src/cache.spec.ts
@@ -1,11 +1,11 @@
-import { DefaultCache } from './cache';
+import Cache from './cache';
 import { getResponse } from './responses.mock';
 
-describe('DefaultCache', () => {
-    let cache: DefaultCache;
+describe('Cache', () => {
+    let cache: Cache;
 
     beforeEach(() => {
-        cache = new DefaultCache();
+        cache = new Cache();
     });
 
     it('returns null when a cache key does not exist', () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -12,7 +12,7 @@ interface CacheMap {
     [key: string]: Response<any>;
 }
 
-export class DefaultCache implements Cache {
+export default class Cache implements Cache {
     private readonly _cache: CacheMap = {};
 
     read<T>(url: string, options: RequestOptions): Response<T> | null {

--- a/src/request-sender.spec.ts
+++ b/src/request-sender.spec.ts
@@ -1,5 +1,6 @@
 import * as cookie from 'js-cookie';
 
+import Cache from './cache';
 import PayloadTransformer from './payload-transformer';
 import RequestFactory from './request-factory';
 import RequestSender from './request-sender';
@@ -301,10 +302,10 @@ describe('RequestSender', () => {
         });
 
         it('uses custom Cache instance if provided', () => {
-            const customCache = {
-                read: jest.fn(),
-                write: jest.fn(),
-            };
+            const customCache = new Cache();
+
+            customCache.read = jest.fn();
+            customCache.write = jest.fn();
 
             const options = { cache: customCache };
             const response = getResponse({ message: 'foobar' });

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -1,7 +1,7 @@
 import { CookiesStatic } from 'js-cookie';
 import merge from 'lodash/merge';
 
-import Cache, { DefaultCache } from './cache';
+import Cache from './cache';
 import isPromise from './is-promise';
 import PayloadTransformer from './payload-transformer';
 import RequestFactory from './request-factory';
@@ -19,7 +19,7 @@ export default class RequestSender {
         private _cookie: CookiesStatic,
         private _options: RequestSenderOptions = {}
     ) {
-        this._cache = this._options.cache || new DefaultCache();
+        this._cache = this._options.cache || new Cache();
     }
 
     sendRequest<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {


### PR DESCRIPTION
## What?
Expose `Cache` so that you can create custom cache instances.

## Why?
`DefaultCache` wasn't exposed initially. You would have to create your own Cache factory. This should enable importing the Cache creator to initialize a new instance.

## Testing / Proof
Updated tests accordingly.

@bigcommerce/frontend
