### PR TITLE
feat(request): change response types from any to unknown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coverage
 /lib
 /node_modules
+.vscode

--- a/src/payload-transformer.ts
+++ b/src/payload-transformer.ts
@@ -23,7 +23,7 @@ export default class PayloadTransformer {
         return options.body;
     }
 
-    toResponse(xhr: XMLHttpRequest): Response {
+    toResponse<T = unknown>(xhr: XMLHttpRequest): Response<T> {
         const headers = this._parseResponseHeaders(xhr.getAllResponseHeaders());
 
         // Using `responseText` to support legacy IE

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -22,7 +22,7 @@ export default class RequestSender {
         this._cache = this._options.cache || new DefaultCache();
     }
 
-    sendRequest<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
+    sendRequest<T = unknown>(url: string, options?: RequestOptions): Promise<Response<T>> {
         const requestOptions = this._mergeDefaultOptions(url, options);
         const cachedRequest = this._getCachedRequest<T>(url, requestOptions);
 
@@ -34,7 +34,7 @@ export default class RequestSender {
 
         return new Promise((resolve, reject) => {
             const requestHandler = () => {
-                const response = this._payloadTransformer.toResponse(request);
+                const response = this._payloadTransformer.toResponse<T>(request);
 
                 if (response.status >= 200 && response.status < 300) {
                     this._cacheRequest(url, requestOptions, response);
@@ -62,23 +62,23 @@ export default class RequestSender {
         });
     }
 
-    get<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
+    get<T = unknown>(url: string, options?: RequestOptions): Promise<Response<T>> {
         return this.sendRequest(url, { ...options, method: 'GET' });
     }
 
-    post<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
+    post<T = unknown>(url: string, options?: RequestOptions): Promise<Response<T>> {
         return this.sendRequest(url, { ...options, method: 'POST' });
     }
 
-    put<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
+    put<T = unknown>(url: string, options?: RequestOptions): Promise<Response<T>> {
         return this.sendRequest(url, { ...options, method: 'PUT' });
     }
 
-    patch<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
+    patch<T = unknown>(url: string, options?: RequestOptions): Promise<Response<T>> {
         return this.sendRequest(url, { ...options, method: 'PATCH' });
     }
 
-    delete<T = any>(url: string, options?: RequestOptions): Promise<Response<T>> {
+    delete<T = unknown>(url: string, options?: RequestOptions): Promise<Response<T>> {
         return this.sendRequest(url, { ...options, method: 'DELETE' });
     }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,6 +1,6 @@
 import Headers from './headers';
 
-export default interface Response<T = any> {
+export default interface Response<T> {
     body: T;
     headers: Headers;
     status: number;

--- a/src/responses.mock.ts
+++ b/src/responses.mock.ts
@@ -6,7 +6,7 @@ export function getResponse(
     headers: Headers = {},
     status: number = 200,
     statusText: string = 'OK'
-): Response {
+): Response<any> {
     return {
         body,
         headers: {
@@ -23,7 +23,7 @@ export function getErrorResponse(
     headers: Headers = {},
     status: number = 400,
     statusText: string = 'Bad Request'
-): Response {
+): Response<any> {
     return {
         body,
         headers: {
@@ -35,7 +35,7 @@ export function getErrorResponse(
     };
 }
 
-export function getTimeoutResponse(): Response {
+export function getTimeoutResponse(): Response<any> {
     return {
         body: '',
         headers: {},


### PR DESCRIPTION
## What?
Change `Response` type to `unknown` to better reflect the response.

## Why?
The will help reduce type errors and more accurately types the response.

## Known Issues
This will only work in TS 3.8+ due to a regression bug in TS:
https://github.com/microsoft/TypeScript/issues/33568

## Testing / Proof
Manual.
<img width="904" alt="Screen Shot 2020-05-05 at 1 14 13 PM" src="https://user-images.githubusercontent.com/10539418/81101795-40d2f700-8ed4-11ea-9e59-34e588152d2c.png">

ping: @bigcommerce/frontend 