### PR TITLE
fix(common): CHP-6524 query-string@6 doesn't support older browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,12 +1163,9 @@
       "dev": true
     },
     "@types/query-string": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-6.3.0.tgz",
-      "integrity": "sha512-yuIv/WRffRzL7cBW+sla4HwBZrEXRNf1MKQ5SklPEadth+BKbDxiVG8A3iISN5B3yC4EeSCzMZP8llHTcUhOzQ==",
-      "requires": {
-        "query-string": "*"
-      }
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-5.1.0.tgz",
+      "integrity": "sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -6514,8 +6511,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6953,13 +6949,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
-      "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "quick-lru": {
@@ -7761,11 +7757,6 @@
         "through": "2"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7948,9 +7939,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "@types/js-cookie": "^2.2.6",
     "@types/lodash": "^4.14.150",
-    "@types/query-string": "^6.3.0",
+    "@types/query-string": "^5.1.0",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.15",
-    "query-string": "^6.12.1",
+    "query-string": "^5.1.1",
     "tslib": "^1.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What?
Bump `query-string` version to `5.x.x`.

## Why?
`query-string` stopped supporting older browsers in version `6.x.x`.

## Testing / Proof
Unit.

Fixes #25