### PR TITLE
fix(common): INT-2280 Allow removal of XSRF Token for remote API call

### DIFF
--- a/src/request-factory.spec.ts
+++ b/src/request-factory.spec.ts
@@ -66,5 +66,25 @@ describe('RequestFactory', () => {
 
             expect(xhr.open).toHaveBeenCalledWith('GET', `${url}?bar=bar&foo=foo&foobar=foo,bar`, true);
         });
+
+        it('configures XHR object without null headers', () => {
+            const xhr = requestFactory.createRequest(url, {
+                credentials: false,
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json, text/plain, */*',
+                    'Content-Type': 'application/json',
+                    'X-XSRF-TOKEN': null,
+                    Authorization: 'auth_key',
+                },
+            });
+
+            expect(xhr.withCredentials).toEqual(false);
+            expect(xhr.open).toHaveBeenCalledWith('POST', url, true);
+            expect(xhr.setRequestHeader).toHaveBeenCalledWith('Accept', 'application/json, text/plain, */*');
+            expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+            expect(xhr.setRequestHeader).not.toHaveBeenCalledWith('X-XSRF-TOKEN', null);
+            expect(xhr.setRequestHeader).toHaveBeenCalledWith('Authorization', 'auth_key');
+        });
     });
 });

--- a/src/request-factory.ts
+++ b/src/request-factory.ts
@@ -29,7 +29,9 @@ export default class RequestFactory {
     }
 
     private _configureRequestHeaders(xhr: XMLHttpRequest, headers: Headers): void {
-        Object.keys(headers).forEach(key => {
+        Object.keys(headers)
+            .filter(key => headers[key] !== null)
+            .forEach(key => {
             xhr.setRequestHeader(key, headers[key]);
         });
     }


### PR DESCRIPTION
[INT-2280](https://jira.bigcommerce.com/browse/INT-2280)

## What?
Remove headers that are null

## Why?
To allow the removal of a default option

## Testing / Proof
Unit.

@bigcommerce/frontend @bigcommerce/apex-integrations @bigcommerce/checkout 
