### PR TITLE
feat(common): RS-28 Publish as es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prebuild": "rm -rf lib",
     "build:cjs": "tsc --outDir lib --project tsconfig-build.json",
-    "build:esm": "tsc --outDir esm --project tsconfig-build.json --target ES2015 --module esnext",
+    "build:esm": "tsc --outDir esm --project tsconfig-build.json --target es5 --module esnext",
     "build": "npm run build:cjs && npm run build:esm",
     "lint": "tslint 'src/**/*.ts' --config tslint.json --project tsconfig.json && tsc --noEmit",
     "prepare": "npm run build",


### PR DESCRIPTION
## What?
After a bunch of investigation, reading and getting advices from @ljharb I learnt that when publishing a module, it is better to publish as es5 so that when this is required it doesn't need to be transpiled by babel.

## Why?
So that packages which depend on this don't need to transpile again.

## Testing / Proof
NA

@bigcommerce/frontend @chanceaclark 
