### PR TITLE
fix(common): CHP-00 remove esm folder on prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/bigcommerce/request-sender-js",
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "prebuild": "rm -rf lib; rm -rf esm",
     "build:cjs": "tsc --outDir lib --project tsconfig-build.json",
     "build:esm": "tsc --outDir esm --project tsconfig-build.json --target ES2015 --module esnext",
     "build": "npm run build:cjs && npm run build:esm",


### PR DESCRIPTION
## What?
Removes the `esm/` folder on prebuild.

## Why?
Ensure the releases are correct.

## Testing / Proof
...
