### PR TITLE
feat(common): DATA-000 Add header for all requests from Control Panel

### DIFF
--- a/src/request-sender-options.ts
+++ b/src/request-sender-options.ts
@@ -3,4 +3,5 @@ import Cache from './cache';
 export default interface RequestSenderOptions {
     cache?: Cache;
     host?: string;
+    isControlPanel?: boolean;
 }

--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -102,6 +102,10 @@ export default class RequestSender {
             defaultOptions.headers['Content-Type'] = 'application/json';
         }
 
+        if (this._options.isControlPanel && defaultOptions.headers) {
+            defaultOptions.headers['X-Is-ControlPanel'] = true;
+        }
+
         return merge({}, defaultOptions, options);
     }
 


### PR DESCRIPTION
## What?
Add "isControlPanel" param to add a default header for all requests from Control Panel.
This PR is related to another PR in bcapp (see below).
https://github.com/bigcommerce/bigcommerce/pull/45966
This is how we are planning to use this approach

## Why?
We previously had a method in bcapp to define Control Panel requests, but it's working based on the url, and this is not reliable anymore, since we are mostly using micro app approach. This additional header seems to be a good approach to define Control Panel requests

## Testing / Proof
Manually tested

@bigcommerce/frontend
