### PR TITLE
Update typescript config to remove sourcemap generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
-        "inlineSources": true,
         "lib": [
             "dom",
             "dom.iterable",
@@ -16,7 +15,6 @@
         "moduleResolution": "node",
         "removeComments": true,
         "skipLibCheck": true,
-        "sourceMap": true,
         "strict": true,
         "stripInternal": true,
         "target": "es5"


### PR DESCRIPTION
## What?
This removes the sourcemap generation from typescript

## Why?
There's no need to build sourcemaps from the typescript builds, because the sourcecode is not available when consuming the package. Sourcemaps should be generated from applications when building them.

## Testing / Proof
...

@bigcommerce/frontend @chanceaclark
