### PR TITLE
fix(request): CHECKOUT-8092 Check if request is made from same domain

### DIFF
--- a/src/request-sender.ts
+++ b/src/request-sender.ts
@@ -94,7 +94,7 @@ export default class RequestSender {
 
         const csrfToken = this._cookie.get('XSRF-TOKEN');
 
-        if (csrfToken && defaultOptions.headers && !this._isAssetRequest(url, options)) {
+        if (csrfToken && defaultOptions.headers && !this._isAssetRequest(url, options) && this._isLocalRequest(url)) {
             defaultOptions.headers['X-XSRF-TOKEN'] = csrfToken;
         }
 
@@ -139,5 +139,13 @@ export default class RequestSender {
         }
 
         return /\.(png|gif|jpe?g|css|js|json|svg|html?)$/.test(url.split('?')[0]);
+    }
+
+    private _isLocalRequest(url: string) {
+        if (url.match(new RegExp('^(https?:)?\/\/' + window.location.hostname))) {
+            return true;
+        }
+
+        return !url.match(new RegExp('^(htttps?:)?\/\/'));
     }
 }


### PR DESCRIPTION
## What?
Add check if request is made from same domain as host window url.

## Why?
In case for embedded checkout we have an issue where login fails since we don't do a check if the request is made from same domain. We implement this check in BCApp for csrf protection header https://github.com/bigcommerce/bigcommerce/blob/a4c98d6a29bc8f3c04e412521f4200c8c6658c47/app/assets/js/csrf-protection-header.js#L96.

## Testing / Proof
- CI

@bigcommerce/frontend
