### PR TITLE
chore(deps): Downgrade js-cookie and @types/js-cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
-        "@types/js-cookie": "^3.0.6",
+        "@types/js-cookie": "^2.2.7",
         "@types/query-string": "^6.3.0",
-        "js-cookie": "^3.0.5",
+        "js-cookie": "^2.2.1",
         "lodash.merge": "^4.6.2",
         "query-string": "^6.14.1",
         "tslib": "^2.8.1"
@@ -1547,9 +1547,10 @@
       }
     },
     "node_modules/@types/js-cookie": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
-      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -6114,12 +6115,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
-    "@types/js-cookie": "^3.0.6",
+    "@types/js-cookie": "^2.2.7",
     "@types/query-string": "^6.3.0",
-    "js-cookie": "^3.0.5",
+    "js-cookie": "^2.2.1",
     "lodash.merge": "^4.6.2",
     "query-string": "^6.14.1",
     "tslib": "^2.8.1"


### PR DESCRIPTION
## What/Why?
Downgrade js-cookie and @types/js-cookie. v3 removed the `get` method and will need some work to support. As such, we'll need to:
- Do this in a major version release of this library (request-sender)
- Support this properly in checkout-sdk-js
- Add sensible test coverage

Effectively reverts https://github.com/bigcommerce/request-sender-js/pull/75